### PR TITLE
Fixing the SplitHostPort parsing issue in Cloudflare

### DIFF
--- a/serve_http.go
+++ b/serve_http.go
@@ -63,10 +63,18 @@ func (r *Disolver) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		}
 
 		if clientIPHeaderName != "" {
-			clientIP, _, _ = net.SplitHostPort(req.Header.Get(clientIPHeaderName))
+			rawIP := req.Header.Get(clientIPHeaderName)
+			var err error
+			clientIP, _, err = net.SplitHostPort(rawIP)
+			if err != nil {
+				clientIP = rawIP
+			}
 		}
-		req.Header.Set(xForwardFor, clientIP)
-		req.Header.Set(xRealIP, clientIP)
+
+		if clientIP != "" {
+			req.Header.Set(xForwardFor, clientIP)
+			req.Header.Set(xRealIP, clientIP)
+		}
 	} else {
 		switch r.provider {
 		case providers.Cloudflare:


### PR DESCRIPTION
In the case of Cloudflare, the CF-Connecting-IP header contains only the IP address, such as 11.22.33.44.

As a result, an error occurs during SplitHostPort parsing, causing the value to be set as empty.